### PR TITLE
Consistent use of the Long type for Detector IDs and Visit Information

### DIFF
--- a/src/main/java/uk/ac/diamond/ispyb/api/DataCollectionGroup.java
+++ b/src/main/java/uk/ac/diamond/ispyb/api/DataCollectionGroup.java
@@ -27,8 +27,8 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 public class DataCollectionGroup {
     private Long id = null;
     private String proposalCode;
-    private Integer proposalNumber;
-    private Integer sessionNumber;
+    private Long proposalNumber;
+    private Long sessionNumber;
     private Long sampleId = null;
     private String sampleBarcode;
     private String experimenttype;
@@ -58,19 +58,19 @@ public class DataCollectionGroup {
         this.proposalCode = proposalCode;
     }
 
-    public Integer getProposalNumber() {
+    public Long getProposalNumber() {
         return this.proposalNumber;
     }
 
-    public void setProposalNumber(Integer proposalNumber) {
+    public void setProposalNumber(Long proposalNumber) {
         this.proposalNumber = proposalNumber;
     }
 
-    public Integer getSessionNumber() {
+    public Long getSessionNumber() {
         return this.sessionNumber;
     }
 
-    public void setSessionNumber(Integer sessionNumber) {
+    public void setSessionNumber(Long sessionNumber) {
         this.sessionNumber = sessionNumber;
     }
 

--- a/src/main/java/uk/ac/diamond/ispyb/api/DataCollectionMain.java
+++ b/src/main/java/uk/ac/diamond/ispyb/api/DataCollectionMain.java
@@ -28,7 +28,7 @@ public class DataCollectionMain {
 
     private Long id;
     private Long groupId;
-    private Integer detectorId;
+    private Long detectorId;
     private Integer blSubsampleId;
     private Integer dcNumber;
     private Timestamp startTime;
@@ -64,11 +64,11 @@ public class DataCollectionMain {
         this.groupId = groupId;
     }
 
-    public Integer getDetectorId() {
+    public Long getDetectorId() {
         return this.detectorId;
     }
 
-    public void setDetectorId(Integer detectorId) {
+    public void setDetectorId(Long detectorId) {
         this.detectorId = detectorId;
     }
 

--- a/src/test/java/uk/ac/diamond/ispyb/test/DataCollectionIntegrationTest.java
+++ b/src/test/java/uk/ac/diamond/ispyb/test/DataCollectionIntegrationTest.java
@@ -85,8 +85,8 @@ public class DataCollectionIntegrationTest{
 	public void testUpsertDataCollectionGroup() throws SQLException, IOException, InterruptedException {
 		DataCollectionGroup dataCollectionGroup = new DataCollectionGroup();
 		dataCollectionGroup.setProposalCode("cm");
-		dataCollectionGroup.setProposalNumber(14451);
-		dataCollectionGroup.setSessionNumber(1);
+		dataCollectionGroup.setProposalNumber(14451L);
+		dataCollectionGroup.setSessionNumber(1L);
 		dataCollectionGroup.setSampleId(11550L);
 		helper.run(api -> api.upsertDataCollectionGroup(dataCollectionGroup));
 	}
@@ -94,8 +94,8 @@ public class DataCollectionIntegrationTest{
 	@Test
 	public void testUpsertDataCollectionGroupWithoutAllFields() throws SQLException, IOException, InterruptedException {
 		DataCollectionGroup dataCollectionGroup = new DataCollectionGroup();
-		dataCollectionGroup.setProposalNumber(14451);
-		dataCollectionGroup.setSessionNumber(1);
+		dataCollectionGroup.setProposalNumber(14451L);
+		dataCollectionGroup.setSessionNumber(1L);
 		dataCollectionGroup.setSampleId(11550L);
 		try{
 			Long id = helper.execute(api -> api.upsertDataCollectionGroup(dataCollectionGroup));
@@ -109,8 +109,8 @@ public class DataCollectionIntegrationTest{
 	public void testUpsertDataCollectionGroupWithTimestamp() throws SQLException, IOException, InterruptedException {
 		DataCollectionGroup dataCollectionGroup = new DataCollectionGroup();
 		dataCollectionGroup.setProposalCode("cm");
-		dataCollectionGroup.setProposalNumber(14451);
-		dataCollectionGroup.setSessionNumber(1);
+		dataCollectionGroup.setProposalNumber(14451L);
+		dataCollectionGroup.setSessionNumber(1L);
 		dataCollectionGroup.setSampleId(11550L);
 		dataCollectionGroup.setStarttime(Timestamp.valueOf(LocalDateTime.now()));
 		dataCollectionGroup.setEndtime(Timestamp.valueOf(LocalDateTime.now()));
@@ -121,8 +121,8 @@ public class DataCollectionIntegrationTest{
 	public void testUpsertDataCollectionGroupGrid() throws SQLException, IOException, InterruptedException {
 		DataCollectionGroup group = new DataCollectionGroup();
 		group.setProposalCode("cm");
-		group.setProposalNumber(14451);
-		group.setSessionNumber(1);
+		group.setProposalNumber(14451L);
+		group.setSessionNumber(1L);
 		group.setSampleId(11550L);
 		
 		Long groupId = helper.execute(api -> api.upsertDataCollectionGroup(group));

--- a/src/test/java/uk/ac/diamond/ispyb/test/DataCollectionIntegrationTest.java
+++ b/src/test/java/uk/ac/diamond/ispyb/test/DataCollectionIntegrationTest.java
@@ -75,7 +75,7 @@ public class DataCollectionIntegrationTest{
 	@Test
 	public void testUpsertDataCollectionMain() throws SQLException, IOException, InterruptedException {
 		DataCollectionMain main = new DataCollectionMain();
-		main.setDetectorId(4);
+		main.setDetectorId(4L);
 		main.setGroupId(988855L);
 		main.setBlSubsampleId(2);
 		helper.run(api -> api.upsertDataCollectionMain(main));


### PR DESCRIPTION
JIRA: SCI-7730

Switches Integers to Longs when dealing with visit information and detector IDs.