### PR TITLE
Use only one version of mariadb connector - 1.4.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
                         <Export-Package>uk.ac.diamond.ispyb.api</Export-Package>
                         <Require-Bundle>
                              org.apache.commons.lang3;bundle-version="3.1.0",
-                             org.mariadb.jdbc;bundle-version="2.4.3",
+                             org.mariadb.jdbc;bundle-version="1.4.6",
                              org.apache.commons.beanutils;bundle-version="1.8.0"
                         </Require-Bundle>
                         <Service-Component>


### PR DESCRIPTION
We were using version 2.4.3 in build plugins and 1.4.6 as a dependency. 

I've changed it to use 1.4.6 in both places. 