### PR TITLE
 Two new container statuses: IN_TRANSIT_TO_LOADLOCK + IN_LOADLOCK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,8 @@ jdk:
   - oraclejdk8
 script:
   - mvn -Dispyb.url=jdbc:mariadb://localhost:3306 -Dispyb.user=root -Dispyb.host=localhost package
-  - sonar-scanner
 addons:
   mariadb: '10.3'
-  sonarqube:
-    token:
-      secure: ei93Y9Nw5Jx8cfY92D5Xm/hBENmgnUOxAaIIEO0zkeDgTgSE884C/nCCD9fqxmeRdUFAAbGt8tXbDv0xEI1ucGLYicBE6Z5E7WT3ujsh7JJOnJ/FO8rT2hobMH27kA7a/vdXl4cPIPKXRf13CDgzRarPqqobW8b/VHNt1haRCuzJaFXzXgE0NNv+7kRUhZEr+jlR73RKzhTPnUiVYWXETD4uBBRW0wFBhu9SSFesI7Pef01QLEEunRmEy+XvD/e4UCQeCtTN5A+nm+il+emKxigH/iib+Vu/LQMuUJ9v31gzKwt2B2gjY9s/uLNiqiHwNWUtCqKzwLNIfmBahn8pdflSXLHq9eJs5anfGPYXpxouSTiB08zcsCJ07BAXnxHwkZk5ARLMIEke00MBREvH/cDKu7hygIbCGCpd8VFtID5CFzSHC3Nf+W8NUlZlDOTTyBiUKK54OMfsGzczKOP1tZECJfKuUkNNJn4lBRPEaGFqQhWXvu3MG4j1fp3E+LM0eQk9KfsBSUnHoPhIKC55eQ5B6EaU8VtMnzLsrryxqIDXYoOuCEjlEt7GoaXUWArQ2kpgT7ZUZhFLkGOagjW8fS+PS3IglpP6mf+yPKiwbHJazbQdwl6ZJ+W4QHMJ8eySjObSXAH3S2r3f/Ke+MZlsj3gRxCQMZPowUMNX3NPwms=
 deploy:
   provider: releases
   api_key:

--- a/downloadschemascript.sh
+++ b/downloadschemascript.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version=1.6.2
+version=1.13.0
 fname=ispyb-database-${version}.tar.gz
 
 cd target/test-classes

--- a/src/main/java/uk/ac/diamond/ispyb/api/ContainerStatus.java
+++ b/src/main/java/uk/ac/diamond/ispyb/api/ContainerStatus.java
@@ -23,6 +23,8 @@ public enum ContainerStatus {
 	IN_TRANSIT_TO_STORAGE("in_transit_to_storage"),
 	IN_TRANSIT_LOADING("in_transit_loading"),
 	IN_TRANSIT_UNLOADING("in_transit_unloading"),
+  IN_LOADLOCK("in_loadlock"),
+  IN_TRANSIT_TO_LOADLOCK("in_transit_to_loadlock"),
 	INVALID("invalid")
 	;
 

--- a/src/test/java/uk/ac/diamond/ispyb/test/PlateIntegrationTest.java
+++ b/src/test/java/uk/ac/diamond/ispyb/test/PlateIntegrationTest.java
@@ -103,6 +103,29 @@ public class PlateIntegrationTest {
                 assertThat(entries, is(equalTo(Arrays.asList(expected))));
         }
 
+        @Test
+        public void testUpdateContaineStatus() throws SQLException, IOException{
+                helper.run(api-> api.updateContainerStatus("test_plate2", ContainerStatus.IN_TRANSIT_TO_LOADLOCK));
+                helper.run(api-> api.updateContainerStatus("test_plate2", ContainerStatus.IN_LOADLOCK));
+
+		            ContainerInfo containerInfo = helper.execute(api -> api.retrieveContainerInfo("test_plate2")).get();
+
+                ContainerInfo expected = new ContainerInfo();
+                expected.setName("test_plate2");
+                expected.setType("CrystalQuickX");
+                expected.setBarcode("test_plate2");
+                expected.setBeamline("i03");
+                expected.setLocation("3");
+                expected.setImagerName("Imager1 20c");
+                expected.setImagerSerialNumber("Z125434");
+                expected.setStatus(ContainerStatus.IN_LOADLOCK.getStatus());
+                expected.setCapacity(192);
+                expected.setStorageTemperature(20.0f);
+                expected.setProposalCode(null);
+
+                assertThat(containerInfo, is(equalTo(expected)));
+        }
+
 	@Test
 	public void testShouldRetrieveContainerOnGonio() throws Exception {
 		List<ContainerInfo> beans = helper.execute(api -> api.retrieveContainerOnGonio("notusedinthestoredprocedure!!!"));


### PR DESCRIPTION
- Use ispyb-database v1.13.0
- Two new container statuses: IN_TRANSIT_TO_LOADLOCK + IN_LOADLOCK
- Test method for new container statuses
- Temporarily remove sonarqube (seems it doesn't play nice with oraclejdk8)
