### PR TITLE
Upgrade MariaDB Connector/J to 2.6.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
 jdk:
   - oraclejdk8
 script:
-  - mvn -Dispyb.url=jdbc:mariadb://localhost:3306 -Dispyb.user=root -Dispyb.host=localhost package
+  - mvn -Dispyb.url='jdbc:mariadb://localhost:3306?useMysqlMetadata' -Dispyb.user=root -Dispyb.host=localhost package
 addons:
   mariadb: '10.3'
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
 jdk:
   - oraclejdk8
 script:
-  - mvn -Dispyb.url='jdbc:mariadb://localhost:3306?useMysqlMetadata' -Dispyb.user=root -Dispyb.host=localhost package
+  - mvn -Dispyb.url='jdbc:mariadb://localhost:3306' -Dispyb.user=root -Dispyb.host=localhost package
 addons:
   mariadb: '10.3'
 deploy:

--- a/README.md
+++ b/README.md
@@ -27,10 +27,8 @@ mvn -Dispyb.url={jdbc_url} -Dispyb.user={user} -Dispyb.pw={password} -Dispyb.hos
 Example:
 
 ```bash
-mvn -Dispyb.url='jdbc:mariadb://localhost:3306?useMysqlMetadata' -Dispyb.user=maven -Dispyb.pw='password_here' -Dispyb.host=localhost package
+mvn -Dispyb.url='jdbc:mariadb://localhost:3306' -Dispyb.user=maven -Dispyb.pw='password_here' -Dispyb.host=localhost package
 ```
-
-We need the 'useMysqlMetadata' parameter so we can pretend it's a MySQL database so that Spring Framework will allow us to use stored procedures the same way it did with previous versions of the MariaDB Connector. For details, see the Connector [documentation page](https://mariadb.com/kb/en/about-mariadb-connector-j/#essential-parameters).
 
 To run a particular test class:
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ mvn -Dispyb.url={jdbc_url} -Dispyb.user={user} -Dispyb.pw={password} -Dispyb.hos
 Example:
 
 ```bash
-mvn -Dispyb.url=jdbc:mariadb://localhost/ -Dispyb.user=maven -Dispyb.pw='password_here' -Dispyb.host=localhost package
+mvn -Dispyb.url='jdbc:mariadb://localhost:3306?useMysqlMetadata' -Dispyb.user=maven -Dispyb.pw='password_here' -Dispyb.host=localhost package
 ```
+
+We need the 'useMysqlMetadata' parameter so we can pretend it's a MySQL database so that Spring Framework will allow us to use stored procedures the same way it did with previous versions of the MariaDB Connector. For details, see the Connector [documentation page](https://mariadb.com/kb/en/about-mariadb-connector-j/#essential-parameters).
 
 Release
 -------

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ mvn -Dispyb.url='jdbc:mariadb://localhost:3306?useMysqlMetadata' -Dispyb.user=ma
 
 We need the 'useMysqlMetadata' parameter so we can pretend it's a MySQL database so that Spring Framework will allow us to use stored procedures the same way it did with previous versions of the MariaDB Connector. For details, see the Connector [documentation page](https://mariadb.com/kb/en/about-mariadb-connector-j/#essential-parameters).
 
+To run a particular test class:
+
+```bash
+mvn -Dispyb.url={jdbc_url} -Dispyb.user={user} -Dispyb.pw={password} -Dispyb.host={host} -Dtest={TestClassName} test
+```
+
 Release
 -------
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
                         <Export-Package>uk.ac.diamond.ispyb.api</Export-Package>
                         <Require-Bundle>
                              org.apache.commons.lang3;bundle-version="3.1.0",
-                             org.mariadb.jdbc;bundle-version="1.4.6",
+                             org.mariadb.jdbc;bundle-version="2.6.2",
                              org.apache.commons.beanutils;bundle-version="1.8.0"
                         </Require-Bundle>
                         <Service-Component>
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
-            <version>1.4.6</version>
+            <version>2.6.2</version>
         </dependency>
         <dependency>
             <groupId>commons-beanutils</groupId>

--- a/src/main/java/uk/ac/diamond/ispyb/dao/BeanTemplateWrapper.java
+++ b/src/main/java/uk/ac/diamond/ispyb/dao/BeanTemplateWrapper.java
@@ -43,7 +43,8 @@ public class BeanTemplateWrapper {
 			String message = "could not return parameter " + key + " from map with keys" + map.keySet();
 			throw new UnsupportedOperationException(message);
 		}
-		return Optional.of((T) map.get(key));
+		Integer i = (Integer)map.get(key);
+		return Optional.of((T)(Long)i.longValue());
 	}
 
 	<T> Optional<T> callIspyb(String procedure, Class<T> clazz, Object bean) {

--- a/src/main/java/uk/ac/diamond/ispyb/dao/BeanTemplateWrapper.java
+++ b/src/main/java/uk/ac/diamond/ispyb/dao/BeanTemplateWrapper.java
@@ -23,11 +23,11 @@ public class BeanTemplateWrapper {
 	private TemplateWrapper templateWrapper;
 	private ResultMapParser parser;
 
-	public BeanTemplateWrapper(TemplateWrapper templateWrapper, ResultMapParser parser){
+	public BeanTemplateWrapper(TemplateWrapper templateWrapper, ResultMapParser parser) {
 		this.templateWrapper = templateWrapper;
 		this.parser = parser;
 	}
-	
+
 	public void updateIspyb(String procedure, Object bean) {
 		templateWrapper.updateIspyb(procedure, convertToMap(bean));
 	}
@@ -35,16 +35,42 @@ public class BeanTemplateWrapper {
 	<T> List<T> callIspybForList(String procedure, Class<T> clazz, Object bean) {
 		return templateWrapper.callIspybForList(procedure, clazz, convertToMap(bean));
 	}
-	
+
 	@SuppressWarnings("unchecked")
 	<T> Optional<T> callIspybForKey(String procedure, Class<T> clazz, Object bean, String key) {
 		Map<String, Object> map = execute(procedure, bean);
-		if (!map.containsKey(key) || map.get(key) == null){
+		if (!map.containsKey(key) || map.get(key) == null) {
 			String message = "could not return parameter " + key + " from map with keys" + map.keySet();
 			throw new UnsupportedOperationException(message);
 		}
-		Integer i = (Integer)map.get(key);
-		return Optional.of((T)(Long)i.longValue());
+		Object o = map.get(key);
+
+		if (clazz.isInstance(new Long(0))) {
+			Long l = null;
+			if (o instanceof Integer)
+				l = ((Integer)o).longValue();
+			else if (o instanceof Byte)
+				l = ((Byte)o).longValue();
+			else if (o instanceof Long)
+				l = (Long)o;
+			return Optional.of((T)l);
+		}
+		else if (clazz.isInstance(new Integer(0))) {
+			Integer i = null;
+			if (o instanceof Integer)
+				i = (Integer)o;
+			else if (o instanceof Byte)
+				i = ((Byte)o).intValue();
+			return Optional.of((T)i);
+		}
+		else if (clazz.isInstance(new Byte((byte)0))) {
+			Byte b = null;
+			if (o instanceof Byte)
+				b = (Byte)o;
+			return Optional.of((T)b);
+		}
+		else
+			return null;
 	}
 
 	<T> Optional<T> callIspyb(String procedure, Class<T> clazz, Object bean) {

--- a/src/main/java/uk/ac/diamond/ispyb/dao/IspybDaoFactory.java
+++ b/src/main/java/uk/ac/diamond/ispyb/dao/IspybDaoFactory.java
@@ -19,6 +19,7 @@ import uk.ac.diamond.ispyb.api.Schema;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.function.BiFunction;
@@ -60,7 +61,12 @@ public class IspybDaoFactory<T> implements IspybFactoryService<T>{
 		Connection connection = null;
 		if (url.contains("mariadb")) {
 			MariaDbDataSource source = new MariaDbDataSource();
-			source.setUrl(url);
+
+			if (url.toString().contains("?"))
+				source.setUrl(url + "&useMysqlMetadata=true");
+			else
+				source.setUrl(url + "?useMysqlMetadata=true");
+
 			username.ifPresent(t -> {
 				try {
 					source.setUserName(t);

--- a/src/main/java/uk/ac/diamond/ispyb/dao/IspybDaoFactory.java
+++ b/src/main/java/uk/ac/diamond/ispyb/dao/IspybDaoFactory.java
@@ -19,7 +19,6 @@ import uk.ac.diamond.ispyb.api.Schema;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.function.BiFunction;

--- a/src/main/java/uk/ac/diamond/ispyb/dao/IspybDaoFactory.java
+++ b/src/main/java/uk/ac/diamond/ispyb/dao/IspybDaoFactory.java
@@ -23,6 +23,9 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.function.BiFunction;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 public class IspybDaoFactory<T> implements IspybFactoryService<T>{
 	private final BiFunction<TemplateWrapper, BeanTemplateWrapper, T> daoFactory;  
 	
@@ -58,8 +61,22 @@ public class IspybDaoFactory<T> implements IspybFactoryService<T>{
 		if (url.contains("mariadb")) {
 			MariaDbDataSource source = new MariaDbDataSource();
 			source.setUrl(url);
-			username.ifPresent(source::setUserName);
-			password.ifPresent(source::setPassword);
+			username.ifPresent(t -> {
+				try {
+					source.setUserName(t);
+				} catch (SQLException e) {
+					Logger logger = Logger.getLogger(IspybDaoFactory.class.getName());
+					logger.log(Level.SEVERE, "Unable to set database username");
+				}
+			});
+			password.ifPresent(t -> {
+				try {
+					source.setPassword(t);
+				} catch (SQLException e) {
+					Logger logger = Logger.getLogger(IspybDaoFactory.class.getName());
+					logger.log(Level.SEVERE, "Unable to set database password");
+				}
+			});
 			connection = source.getConnection();
 		} else {
 			SingleConnectionDataSource ds = new SingleConnectionDataSource(url, false);

--- a/src/main/java/uk/ac/diamond/ispyb/dao/IspybPlateDAO.java
+++ b/src/main/java/uk/ac/diamond/ispyb/dao/IspybPlateDAO.java
@@ -116,7 +116,7 @@ public class IspybPlateDAO implements IspybPlateApi{
 
 	@Override
 	public Byte upsertSleeve(Sleeve sleeve) throws SQLException {
-		return (byte)((int)(beanTemplateWrapper.callIspybForKey("upsert_sleeve", Integer.class, sleeve, "p_id").get()));
+		return beanTemplateWrapper.callIspybForKey("upsert_sleeve", Byte.class, sleeve, "p_id").get();
 	}
 
 	@Override

--- a/src/test/java/uk/ac/diamond/ispyb/test/DataCollectionIntegrationTest.java
+++ b/src/test/java/uk/ac/diamond/ispyb/test/DataCollectionIntegrationTest.java
@@ -23,6 +23,7 @@ import java.sql.Timestamp;
 import java.time.LocalDateTime;
 
 import org.springframework.jdbc.UncategorizedSQLException;
+import org.springframework.dao.TransientDataAccessResourceException;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -102,7 +103,7 @@ public class DataCollectionIntegrationTest{
 		try{
 			Long id = helper.execute(api -> api.upsertDataCollectionGroup(dataCollectionGroup));
 			assertThat(id, notNullValue());
-		} catch (UnsupportedOperationException | UncategorizedSQLException e){
+		} catch (UnsupportedOperationException | UncategorizedSQLException | TransientDataAccessResourceException e){
 			// do nothing, expecting a sql exception
 		}
 	}


### PR DESCRIPTION
The current MariaDB Connector/J us woefully out of date.

This PR will try to upgrade to the currently latest version, 2.6.2.

SpringFramework unfortunately does not support MariaDB properly for stored procedures, so we need to pretend it's a MySQL database for the stored procedure calls to continue to function.