### PR TITLE
Add 'CAPILLARY' enum option to reflect new DB enum option

### DIFF
--- a/src/main/java/uk/ac/diamond/ispyb/api/SampleGroupType.java
+++ b/src/main/java/uk/ac/diamond/ispyb/api/SampleGroupType.java
@@ -12,5 +12,5 @@
 package uk.ac.diamond.ispyb.api;
 
 public enum SampleGroupType {
-    BACKGROUND, CONTAINER, SAMPLE, CALIBRANT;
+    BACKGROUND, CONTAINER, SAMPLE, CALIBRANT, CAPILLARY;
 }


### PR DESCRIPTION
We've added an enum option 'capillary' to the `BLSampleGroup_has_BLSample` database table, so this adds the same to the corresponding Java enum. 