### PR TITLE
Include sampleOrderInPlan in result from retrieveDataCollectionPlansForSample(..) method

### DIFF
--- a/downloadschemascript.sh
+++ b/downloadschemascript.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version=1.16.0
+version=1.20.1
 fname=ispyb-database-${version}.tar.gz
 
 cd target/test-classes

--- a/src/main/java/uk/ac/diamond/ispyb/api/DataCollectionPlan.java
+++ b/src/main/java/uk/ac/diamond/ispyb/api/DataCollectionPlan.java
@@ -18,6 +18,7 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 public class DataCollectionPlan {
     private Long dcPlanId;
     private String name;
+    private Short sampleOrderInPlan;
     private String experimentKind;
     private Double preferredBeamSizeX;
     private Double preferredBeamSizeY;
@@ -50,6 +51,14 @@ public class DataCollectionPlan {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public Short getSampleOrderInPlan() {
+        return sampleOrderInPlan;
+    }
+
+    public void setSampleOrderInPlan(Short sampleOrderInPlan) {
+        this.sampleOrderInPlan = sampleOrderInPlan;
     }
 
     public String getExperimentKind() {

--- a/src/test/java/uk/ac/diamond/ispyb/test/IntegrationTestHelper.java
+++ b/src/test/java/uk/ac/diamond/ispyb/test/IntegrationTestHelper.java
@@ -70,10 +70,10 @@ public class IntegrationTestHelper<S extends Closeable> {
         }
 
         downloadSchema();
-        executeScript("schema/tables.sql", data.getSchema());
-        executeScript("schema/routines.sql", data.getSchema());
-        executeScript("schema/lookups.sql", data.getSchema());
-        executeScript("schema/data.sql", data.getSchema());
+        executeScript("schemas/ispyb/tables.sql", data.getSchema());
+        executeScript("schemas/ispyb/routines.sql", data.getSchema());
+        executeScript("schemas/ispyb/lookups.sql", data.getSchema());
+        executeScript("schemas/ispyb/data.sql", data.getSchema());
 
         this.api = factory.buildIspybApi(data.getUrl(), data.getUser(), data.getPassword(), Optional.of(data.getSchema()));
     }

--- a/src/test/java/uk/ac/diamond/ispyb/test/XpdfIntegrationTest.java
+++ b/src/test/java/uk/ac/diamond/ispyb/test/XpdfIntegrationTest.java
@@ -169,6 +169,7 @@ public class XpdfIntegrationTest {
 		DataCollectionPlan dataCollectionPlan1 = new DataCollectionPlan();
 		dataCollectionPlan1.setDcPlanId(197792L);
 		dataCollectionPlan1.setName("XPDF-1");
+		dataCollectionPlan1.setSampleOrderInPlan((short)1);
 		dataCollectionPlan1.setDetectorId(8L);
 		dataCollectionPlan1.setExposureTime(5.4);
 		dataCollectionPlan1.setDistance(136.86);
@@ -183,6 +184,7 @@ public class XpdfIntegrationTest {
 		DataCollectionPlan dataCollectionPlan2 = new DataCollectionPlan();
 		dataCollectionPlan2.setDcPlanId(197792L);
 		dataCollectionPlan2.setName("XPDF-1");
+		dataCollectionPlan2.setSampleOrderInPlan((short)1);
 		dataCollectionPlan2.setDetectorId(8L);
 		dataCollectionPlan2.setExposureTime(5.4);
 		dataCollectionPlan2.setDistance(136.86);


### PR DESCRIPTION
- Use ispyb-database v1.20.1 which has a new directory structure
- Add sampleOrderInPlan field to DataCollectionPlan class
- Modify test to check for sampleOrderInPlan values