### PR TITLE
Add I22 parameters to SCM sample

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,12 +2,6 @@ variables:
   MYSQL_ROOT_PASSWORD: mysql_root_pwd
 
 trigger:
-  branches:
-    include:
-    - '*'
-  tags:
-    include:
-    - '*'
   paths:
     exclude:
     - '*.md'

--- a/downloadschemascript.sh
+++ b/downloadschemascript.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version=1.22.0
+version=1.25.1
 fname=ispyb-database-${version}.tar.gz
 
 cd target/test-classes

--- a/downloadschemascript.sh
+++ b/downloadschemascript.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version=1.25.1
+version=1.25.2
 fname=ispyb-database-${version}.tar.gz
 
 cd target/test-classes

--- a/src/main/java/uk/ac/diamond/ispyb/api/ScmSample.java
+++ b/src/main/java/uk/ac/diamond/ispyb/api/ScmSample.java
@@ -48,6 +48,9 @@ public class ScmSample {
     private Float planRobotPlateTemperature;
     private Float planExposureTemperature;
     private Float planTransmission;
+    private Float planQMin;
+    private Float planQMax;
+    private String planreductionParametersAveraging;
     private String proposalCode;
     private String proposalNumber;
     private Long sessionNumber;
@@ -316,6 +319,30 @@ public class ScmSample {
 
     public void setPlanTransmission(Float planTransmission) {
         this.planTransmission = planTransmission;
+    }
+
+    public Float getPlanQMin() {
+        return planQMin;
+    }
+
+    public void setPlanQMin(Float planQMin) {
+        this.planQMin = planQMin;
+    }
+
+    public Float getPlanQMax() {
+        return planQMax;
+    }
+
+    public void setPlanQMax(Float planQMax) {
+        this.planQMax = planQMax;
+    }
+
+    public String getPlanreductionParametersAveraging() {
+        return planreductionParametersAveraging;
+    }
+
+    public void setPlanreductionParametersAveraging(String planreductionParametersAveraging) {
+        this.planreductionParametersAveraging = planreductionParametersAveraging;
     }
 
     @Override

--- a/src/main/java/uk/ac/diamond/ispyb/api/ScmSample.java
+++ b/src/main/java/uk/ac/diamond/ispyb/api/ScmSample.java
@@ -50,7 +50,7 @@ public class ScmSample {
     private Float planTransmission;
     private Float planQMin;
     private Float planQMax;
-    private String planreductionParametersAveraging;
+    private String planReductionParametersAveraging;
     private String proposalCode;
     private String proposalNumber;
     private Long sessionNumber;
@@ -337,12 +337,12 @@ public class ScmSample {
         this.planQMax = planQMax;
     }
 
-    public String getPlanreductionParametersAveraging() {
-        return planreductionParametersAveraging;
+    public String getPlanReductionParametersAveraging() {
+        return planReductionParametersAveraging;
     }
 
-    public void setPlanreductionParametersAveraging(String planreductionParametersAveraging) {
-        this.planreductionParametersAveraging = planreductionParametersAveraging;
+    public void setPlanReductionParametersAveraging(String planReductionParametersAveraging) {
+        this.planReductionParametersAveraging = planReductionParametersAveraging;
     }
 
     @Override


### PR DESCRIPTION
- Use ispyb-database v1.25.2 which contains updated stored procedures for retrieving SCM samples
- Add the special i22 data collection plan parameters (incl. getters & setters) to the ScmSample class